### PR TITLE
Fix translation loader configuration order

### DIFF
--- a/apps/web/src/app/app.config.ts
+++ b/apps/web/src/app/app.config.ts
@@ -15,11 +15,11 @@ export const appConfig: ApplicationConfig = {
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideHttpClient(withFetch()),
+    importProvidersFrom(TranslateModule.forRoot({ defaultLanguage: 'az' })),
     ...provideTranslateHttpLoader({
       prefix: 'assets/i18n/',
       suffix: '.json'
     }),
-    importProvidersFrom(TranslateModule.forRoot()),
     provideRouter(routes)
   ]
 };


### PR DESCRIPTION
## Summary
- configure the root TranslateModule with the default language before overriding the HTTP loader
- ensure the translation loader provider comes last so language JSON files load correctly

## Testing
- npm run build -- --configuration development

------
https://chatgpt.com/codex/tasks/task_e_68d95bc2f420832a86385c8702c68d3d