### PR TITLE
Automate Telegram bot provisioning via BotFather

### DIFF
--- a/apps/server/config/telegram.config.json
+++ b/apps/server/config/telegram.config.json
@@ -1,0 +1,14 @@
+{
+  "botToken": "",
+  "autoCreate": {
+    "enabled": false,
+    "apiId": null,
+    "apiHash": "",
+    "session": "",
+    "botName": "Cargo Broker Bot",
+    "botUsername": "CargoBrokerBot",
+    "description": "",
+    "about": "",
+    "commands": []
+  }
+}

--- a/apps/server/package-lock.json
+++ b/apps/server/package-lock.json
@@ -10,8 +10,15 @@
       "dependencies": {
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
-        "express": "^4.21.1"
+        "express": "^4.21.1",
+        "telegram": "^2.22.2"
       }
+    },
+    "node_modules/@cryptography/aes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@cryptography/aes/-/aes-0.1.1.tgz",
+      "integrity": "sha512-PcYz4FDGblO6tM2kSC+VzhhK62vml6k6/YAkiWtyPvrgJVfnDRoHGDtKn5UiaRRUrvUTTocBpvc2rRgTCqxjsg==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -31,6 +38,44 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.3.2.tgz",
+      "integrity": "sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -54,6 +99,43 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/bufferutil": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
+      "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/bytes": {
@@ -143,6 +225,19 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -169,6 +264,61 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -212,6 +362,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -242,11 +401,66 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -255,6 +469,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "node_modules/express": {
@@ -301,6 +525,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
       }
     },
     "node_modules/finalhandler": {
@@ -397,6 +630,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -419,6 +658,25 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
       }
     },
     "node_modules/http-errors": {
@@ -449,11 +707,49 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -463,6 +759,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -548,6 +850,35 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-localstorage": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-2.2.1.tgz",
+      "integrity": "sha512-vv8fJuOUCCvSPjDjBLlMqYMHob4aGjkmrkaE42/mZr0VT+ZAU10jRF8oTnX9+pgU9/vYJ8P7YT3Vd6ajkmzSCw==",
+      "license": "MIT",
+      "dependencies": {
+        "write-file-atomic": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -581,6 +912,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -589,6 +926,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
@@ -647,6 +990,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/real-cancellable-promise": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/real-cancellable-promise/-/real-cancellable-promise-1.2.3.tgz",
+      "integrity": "sha512-hBI5Gy/55VEeeMtImMgEirD7eq5UmqJf1J8dFZtbJZA/3rB0pYFZ7PayMGueb6v4UtUtpKpP+05L0VwyE1hI9Q==",
+      "license": "MIT"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -806,6 +1155,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -813,6 +1195,50 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/store2": {
+      "version": "2.14.4",
+      "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.4.tgz",
+      "integrity": "sha512-srTItn1GOvyvOycgxjAnPA63FZNwy0PTyUBFMHRM+hVFltAeoh0LmNBz9SZqUS9mMqGk8rfyWyXn3GH5ReJ8Zw==",
+      "license": "MIT"
+    },
+    "node_modules/telegram": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/telegram/-/telegram-2.22.2.tgz",
+      "integrity": "sha512-9payizc801Aqqu4eTGPc0huxKnIwFe0hn18mrpbgAKKiMLurX/UIQW/fjPhI5ONzockDFsaXDFqTreXBoG1u3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@cryptography/aes": "^0.1.1",
+        "async-mutex": "^0.3.0",
+        "big-integer": "^1.6.48",
+        "buffer": "^6.0.3",
+        "htmlparser2": "^6.1.0",
+        "mime": "^3.0.0",
+        "node-localstorage": "^2.2.1",
+        "pako": "^2.0.3",
+        "path-browserify": "^1.0.1",
+        "real-cancellable-promise": "^1.1.1",
+        "socks": "^2.6.2",
+        "store2": "^2.13.0",
+        "ts-custom-error": "^3.2.0",
+        "websocket": "^1.0.34"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.3",
+        "utf-8-validate": "^5.0.5"
+      }
+    },
+    "node_modules/telegram/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -823,6 +1249,27 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -837,6 +1284,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -844,6 +1300,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/utils-merge": {
@@ -862,6 +1331,44 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/websocket": {
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.35.tgz",
+      "integrity": "sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bufferutil": "^4.0.1",
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.63",
+        "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
+        "yaeti": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
+      "license": "ISC",
+      "dependencies": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
+      }
+    },
+    "node_modules/yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.32"
       }
     }
   }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "express": "^4.21.1"
+    "express": "^4.21.1",
+    "telegram": "^2.22.2"
   }
 }

--- a/apps/server/src/bootstrap/telegram.bootstrap.js
+++ b/apps/server/src/bootstrap/telegram.bootstrap.js
@@ -1,0 +1,156 @@
+import { readFile, writeFile } from 'fs/promises';
+import { isAbsolute, resolve } from 'path';
+import { pathToFileURL } from 'url';
+
+const DEFAULT_CONFIG_URL = new URL('../../config/telegram.config.json', import.meta.url);
+
+function sanitiseCommands(commands) {
+  if (!Array.isArray(commands)) {
+    return [];
+  }
+
+  return commands
+    .map((command) => {
+      if (typeof command === 'string') {
+        return command.trim();
+      }
+
+      if (command && typeof command === 'object') {
+        const cmd = typeof command.command === 'string' ? command.command.trim() : '';
+        const description = typeof command.description === 'string' ? command.description.trim() : '';
+        if (!cmd) {
+          return null;
+        }
+
+        return description ? `${cmd} - ${description}` : cmd;
+      }
+
+      return null;
+    })
+    .filter(Boolean);
+}
+
+async function readConfigFile(fileUrl) {
+  try {
+    const file = await readFile(fileUrl, 'utf-8');
+    const data = JSON.parse(file);
+    if (data && typeof data === 'object') {
+      const autoCreate = data.autoCreate && typeof data.autoCreate === 'object' ? data.autoCreate : {};
+      return {
+        botToken: typeof data.botToken === 'string' ? data.botToken.trim() : '',
+        autoCreate: {
+          enabled: Boolean(autoCreate.enabled),
+          apiId: typeof autoCreate.apiId === 'number' ? autoCreate.apiId : null,
+          apiHash: typeof autoCreate.apiHash === 'string' ? autoCreate.apiHash.trim() : '',
+          session: typeof autoCreate.session === 'string' ? autoCreate.session.trim() : '',
+          botName: typeof autoCreate.botName === 'string' ? autoCreate.botName.trim() : '',
+          botUsername: typeof autoCreate.botUsername === 'string' ? autoCreate.botUsername.trim() : '',
+          description: typeof autoCreate.description === 'string' ? autoCreate.description.trim() : '',
+          about: typeof autoCreate.about === 'string' ? autoCreate.about.trim() : '',
+          commands: sanitiseCommands(autoCreate.commands),
+          lastRunAt: typeof autoCreate.lastRunAt === 'string' ? autoCreate.lastRunAt : null,
+          lastError: typeof autoCreate.lastError === 'string' ? autoCreate.lastError : null,
+          lastStatus: typeof autoCreate.lastStatus === 'string' ? autoCreate.lastStatus : null
+        }
+      };
+    }
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  return {
+    botToken: '',
+    autoCreate: {
+      enabled: false,
+      apiId: null,
+      apiHash: '',
+      session: '',
+      botName: '',
+      botUsername: '',
+      description: '',
+      about: '',
+      commands: [],
+      lastRunAt: null,
+      lastError: null,
+      lastStatus: null
+    }
+  };
+}
+
+async function writeConfigFile(fileUrl, data) {
+  await writeFile(fileUrl, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+function resolveConfigUrl() {
+  const envPath = process.env.TELEGRAM_CONFIG_FILE;
+  if (!envPath) {
+    return DEFAULT_CONFIG_URL;
+  }
+
+  const absolutePath = isAbsolute(envPath) ? envPath : resolve(process.cwd(), envPath);
+  return pathToFileURL(absolutePath);
+}
+
+export async function bootstrapTelegram(settingsRepository, { autoCreator } = {}) {
+  const envToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  if (envToken) {
+    await settingsRepository.persistBotToken(envToken);
+    return { source: 'env', botToken: envToken };
+  }
+
+  const storedToken = await settingsRepository.getBotToken();
+  if (storedToken) {
+    process.env.TELEGRAM_BOT_TOKEN = storedToken;
+    return { source: 'settings', botToken: storedToken };
+  }
+
+  const configUrl = resolveConfigUrl();
+  const config = await readConfigFile(configUrl);
+
+  if (config.botToken) {
+    await settingsRepository.persistBotToken(config.botToken);
+    process.env.TELEGRAM_BOT_TOKEN = config.botToken;
+    return { source: 'config', botToken: config.botToken };
+  }
+
+  if (config.autoCreate?.enabled) {
+    const creator = autoCreator ?? (await import('./telegram.bot-factory.js'));
+    if (creator && typeof creator.ensureBotToken === 'function') {
+      try {
+        const result = await creator.ensureBotToken(config.autoCreate);
+        if (result?.botToken) {
+          await settingsRepository.persistBotToken(result.botToken);
+          process.env.TELEGRAM_BOT_TOKEN = result.botToken;
+          const updatedConfig = {
+            ...config,
+            botToken: result.botToken,
+            autoCreate: {
+              ...config.autoCreate,
+              lastRunAt: new Date().toISOString(),
+              lastStatus: result.created ? 'created' : 'retrieved',
+              lastError: null
+            }
+          };
+          await writeConfigFile(configUrl, updatedConfig);
+          return { source: result.created ? 'auto-created' : 'auto-retrieved', botToken: result.botToken };
+        }
+      } catch (error) {
+        const updatedConfig = {
+          ...config,
+          autoCreate: {
+            ...config.autoCreate,
+            lastRunAt: new Date().toISOString(),
+            lastError: error.message ?? String(error),
+            lastStatus: 'failed'
+          }
+        };
+        await writeConfigFile(configUrl, updatedConfig);
+        console.error('Failed to automatically provision Telegram bot token', error);
+      }
+    }
+  }
+
+  return { source: 'none', botToken: null };
+}

--- a/apps/server/src/bootstrap/telegram.bot-factory.js
+++ b/apps/server/src/bootstrap/telegram.bot-factory.js
@@ -1,0 +1,177 @@
+import { TelegramClient } from 'telegram';
+import { StringSession } from 'telegram/sessions/index.js';
+
+import { sleep } from '../utils/sleep.js';
+
+const BOTFATHER_USERNAME = 'BotFather';
+const TOKEN_REGEX = /(\d+:[A-Za-z0-9_-]{10,})/;
+
+function normaliseUsername(username) {
+  if (!username) {
+    return '';
+  }
+
+  const trimmed = username.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  return trimmed.startsWith('@') ? trimmed : `@${trimmed}`;
+}
+
+function stripUsername(username) {
+  return normaliseUsername(username).replace(/^@/, '');
+}
+
+async function getLatestMessage(client, peer) {
+  const [latest] = await client.getMessages(peer, { limit: 1 });
+  return latest ?? null;
+}
+
+async function waitForNewMessage(client, peer, afterId, timeoutMs = 15000) {
+  const deadline = Date.now() + timeoutMs;
+  let lastMessage = null;
+
+  while (Date.now() < deadline) {
+    lastMessage = await getLatestMessage(client, peer);
+    if (lastMessage && lastMessage.id > afterId) {
+      return lastMessage;
+    }
+
+    await sleep(500);
+  }
+
+  throw new Error('Timed out waiting for BotFather response');
+}
+
+function extractToken(message) {
+  if (!message) {
+    return null;
+  }
+
+  const match = message.match(TOKEN_REGEX);
+  return match ? match[1] : null;
+}
+
+async function requestExistingToken(client, username) {
+  const targetUsername = normaliseUsername(username);
+  if (!targetUsername) {
+    return null;
+  }
+
+  const latest = await getLatestMessage(client, BOTFATHER_USERNAME);
+  const baselineId = latest ? latest.id : 0;
+
+  await client.sendMessage(BOTFATHER_USERNAME, { message: `/token ${targetUsername}` });
+  const response = await waitForNewMessage(client, BOTFATHER_USERNAME, baselineId);
+  const token = extractToken(response.message ?? '');
+
+  if (token) {
+    return { botToken: token, created: false, raw: response.message ?? '' };
+  }
+
+  const text = (response.message ?? '').toLowerCase();
+  if (text.includes("wasn't found") || text.includes('not a bot')) {
+    return null;
+  }
+
+  throw new Error(`BotFather refused to return a token: ${response.message ?? 'unknown error'}`);
+}
+
+async function createBot(client, { botName, botUsername }) {
+  const name = botName?.trim();
+  const username = stripUsername(botUsername);
+
+  if (!name) {
+    throw new Error('A bot name is required to create a Telegram bot');
+  }
+
+  if (!username) {
+    throw new Error('A bot username is required to create a Telegram bot');
+  }
+
+  const latest = await getLatestMessage(client, BOTFATHER_USERNAME);
+  let baselineId = latest ? latest.id : 0;
+
+  await client.sendMessage(BOTFATHER_USERNAME, { message: '/newbot' });
+  const namePrompt = await waitForNewMessage(client, BOTFATHER_USERNAME, baselineId);
+  baselineId = namePrompt.id;
+
+  await client.sendMessage(BOTFATHER_USERNAME, { message: name });
+  const usernamePrompt = await waitForNewMessage(client, BOTFATHER_USERNAME, baselineId);
+  baselineId = usernamePrompt.id;
+
+  await client.sendMessage(BOTFATHER_USERNAME, { message: username });
+  const response = await waitForNewMessage(client, BOTFATHER_USERNAME, baselineId, 30000);
+  const token = extractToken(response.message ?? '');
+
+  if (!token) {
+    throw new Error(`BotFather did not provide a token after bot creation: ${response.message ?? 'unknown response'}`);
+  }
+
+  return { botToken: token, created: true, raw: response.message ?? '' };
+}
+
+async function configureBot(client, username, config) {
+  const targetUsername = normaliseUsername(username);
+  if (!targetUsername) {
+    return;
+  }
+
+  async function updateSetting(command, value, timeout = 15000) {
+    const latest = await getLatestMessage(client, BOTFATHER_USERNAME);
+    const baselineId = latest ? latest.id : 0;
+    await client.sendMessage(BOTFATHER_USERNAME, { message: command });
+    const prompt = await waitForNewMessage(client, BOTFATHER_USERNAME, baselineId, timeout);
+    const promptText = prompt.message ?? '';
+    if (!promptText.toLowerCase().includes('choose a bot')) {
+      return;
+    }
+
+    await client.sendMessage(BOTFATHER_USERNAME, { message: targetUsername });
+    const configBaseline = prompt.id;
+    await client.sendMessage(BOTFATHER_USERNAME, { message: value });
+    await waitForNewMessage(client, BOTFATHER_USERNAME, configBaseline, timeout);
+  }
+
+  if (config.description) {
+    await updateSetting('/setdescription', config.description.slice(0, 512));
+  }
+
+  if (config.about) {
+    await updateSetting('/setabouttext', config.about.slice(0, 120));
+  }
+
+  if (config.commands?.length) {
+    const commandsText = config.commands.join('\n').slice(0, 1024);
+    await updateSetting('/setcommands', commandsText);
+  }
+}
+
+export async function ensureBotToken(config) {
+  if (!config || typeof config !== 'object') {
+    return null;
+  }
+
+  const { apiId, apiHash, session } = config;
+  if (!apiId || !apiHash || !session) {
+    throw new Error('Telegram bot auto-creation requires apiId, apiHash and a session string');
+  }
+
+  const client = new TelegramClient(new StringSession(session), apiId, apiHash, { connectionRetries: 5 });
+  await client.connect();
+
+  try {
+    const existing = await requestExistingToken(client, config.botUsername);
+    if (existing) {
+      await configureBot(client, config.botUsername, config);
+      return existing;
+    }
+
+    const created = await createBot(client, config);
+    await configureBot(client, config.botUsername, config);
+    return created;
+  } finally {
+    await client.disconnect();
+  }
+}

--- a/apps/server/src/index.js
+++ b/apps/server/src/index.js
@@ -6,30 +6,39 @@ import { createSettingsRepository } from './services/settings.repository.js';
 import { createTelegramService } from './services/telegram.service.js';
 import { createSettingsRouter } from './routes/settings.routes.js';
 import { createNotificationsRouter } from './routes/notifications.routes.js';
+import { bootstrapTelegram } from './bootstrap/telegram.bootstrap.js';
 
 dotenv.config();
 
-const app = express();
-app.use(cors());
-app.use(express.json({ limit: '1mb' }));
+async function main() {
+  const app = express();
+  app.use(cors());
+  app.use(express.json({ limit: '1mb' }));
 
-const settingsRepository = createSettingsRepository();
-const telegramService = createTelegramService(settingsRepository);
+  const settingsRepository = createSettingsRepository();
+  await bootstrapTelegram(settingsRepository);
+  const telegramService = createTelegramService(settingsRepository);
 
-app.use('/api/settings', createSettingsRouter(settingsRepository));
-app.use('/api/notifications', createNotificationsRouter(telegramService));
+  app.use('/api/settings', createSettingsRouter(settingsRepository, telegramService));
+  app.use('/api/notifications', createNotificationsRouter(telegramService));
 
-app.get('/health', (req, res) => {
-  res.json({ status: 'ok' });
-});
+  app.get('/health', (req, res) => {
+    res.json({ status: 'ok' });
+  });
 
-app.use((err, req, res, next) => {
-  console.error(err);
-  const status = err.status ?? 500;
-  res.status(status).json({ error: err.message, details: err.details });
-});
+  app.use((err, req, res, next) => {
+    console.error(err);
+    const status = err.status ?? 500;
+    res.status(status).json({ error: err.message, details: err.details });
+  });
 
-const port = process.env.PORT ?? 3000;
-app.listen(port, () => {
-  console.log(`Server listening on port ${port}`);
+  const port = process.env.PORT ?? 3000;
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
+
+main().catch((error) => {
+  console.error('Failed to start server', error);
+  process.exit(1);
 });

--- a/apps/server/src/services/telegram.service.js
+++ b/apps/server/src/services/telegram.service.js
@@ -1,22 +1,33 @@
 import { formatOrderMessage } from '../utils/order-formatter.js';
+import { comparePhoneNumbers, sanitisePhoneNumber } from '../utils/phone-number.js';
 
 export class TelegramService {
   constructor(settingsRepository, options = {}) {
     this.settingsRepository = settingsRepository;
-    this.botToken = options.botToken ?? process.env.TELEGRAM_BOT_TOKEN;
+    this.botToken = options.botToken ?? process.env.TELEGRAM_BOT_TOKEN ?? null;
     this.apiBaseUrl = options.apiBaseUrl ?? 'https://api.telegram.org';
   }
 
-  ensureBotToken() {
-    if (!this.botToken) {
-      const error = new Error('Telegram bot token is not configured');
-      error.status = 500;
-      throw error;
+  async ensureBotToken() {
+    if (this.botToken) {
+      return this.botToken;
     }
+
+    if (typeof this.settingsRepository.getBotToken === 'function') {
+      const stored = await this.settingsRepository.getBotToken();
+      if (stored) {
+        this.botToken = stored;
+        return this.botToken;
+      }
+    }
+
+    const error = new Error('Telegram bot token is not configured');
+    error.status = 500;
+    throw error;
   }
 
   async sendOrderNotification(submission) {
-    this.ensureBotToken();
+    await this.ensureBotToken();
     const { chatId } = await this.settingsRepository.getTelegramSettings();
 
     if (!chatId) {
@@ -48,6 +59,53 @@ export class TelegramService {
     }
 
     return response.json();
+  }
+
+  async resolveChatIdByPhoneNumber(phoneNumber) {
+    const sanitised = sanitisePhoneNumber(phoneNumber);
+    const botToken = await this.ensureBotToken();
+
+    const url = `${this.apiBaseUrl}/bot${botToken}/getUpdates`;
+    const response = await fetch(url, { method: 'GET' });
+
+    if (!response.ok) {
+      const body = await response.text();
+      const error = new Error(`Failed to load Telegram updates: ${response.statusText}`);
+      error.status = 502;
+      error.details = body;
+      throw error;
+    }
+
+    const payload = await response.json();
+    if (payload.ok === false) {
+      const error = new Error('Telegram API returned an error while fetching updates');
+      error.status = 502;
+      error.details = payload.description ?? payload;
+      throw error;
+    }
+
+    const updates = Array.isArray(payload.result) ? payload.result : [];
+
+    for (const update of updates) {
+      const message = update.message ?? update.edited_message ?? null;
+      if (!message) {
+        continue;
+      }
+
+      if (message.contact && comparePhoneNumbers(message.contact.phone_number, sanitised)) {
+        return { chatId: String(message.chat.id), phoneNumber: sanitised };
+      }
+
+      if (message.text && comparePhoneNumbers(message.text, sanitised)) {
+        return { chatId: String(message.chat.id), phoneNumber: sanitised };
+      }
+    }
+
+    const error = new Error(
+      'Unable to locate a Telegram chat for the provided phone number. Share your contact with the bot and try again.'
+    );
+    error.status = 404;
+    throw error;
   }
 }
 

--- a/apps/server/src/utils/phone-number.js
+++ b/apps/server/src/utils/phone-number.js
@@ -1,0 +1,28 @@
+export function sanitisePhoneNumber(input) {
+  if (typeof input !== 'string') {
+    throw new Error('Phone number must be a string');
+  }
+
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('Phone number is required');
+  }
+
+  const digitsOnly = trimmed.replace(/\D/g, '');
+  if (digitsOnly.length < 6) {
+    throw new Error('Phone number must contain at least 6 digits');
+  }
+
+  return digitsOnly;
+}
+
+export function comparePhoneNumbers(a, b) {
+  if (!a || !b) {
+    return false;
+  }
+  try {
+    return sanitisePhoneNumber(String(a)) === sanitisePhoneNumber(String(b));
+  } catch (error) {
+    return false;
+  }
+}

--- a/apps/server/src/utils/sleep.js
+++ b/apps/server/src/utils/sleep.js
@@ -1,0 +1,4 @@
+export function sleep(durationMs) {
+  const timeout = Number.isFinite(durationMs) && durationMs > 0 ? durationMs : 0;
+  return new Promise((resolve) => setTimeout(resolve, timeout));
+}

--- a/apps/web/src/app/data-access/models/telegram.model.ts
+++ b/apps/web/src/app/data-access/models/telegram.model.ts
@@ -1,3 +1,6 @@
 export interface TelegramSettings {
+  phoneNumber: string | null;
   chatId: string | null;
+  lastSyncedAt: string | null;
+  botTokenConfigured: boolean;
 }

--- a/apps/web/src/app/data-access/services/telegram-settings.service.spec.ts
+++ b/apps/web/src/app/data-access/services/telegram-settings.service.spec.ts
@@ -31,15 +31,25 @@ describe('TelegramSettingsService', () => {
 
     const request = httpMock.expectOne('/api/settings/telegram');
     expect(request.request.method).toBe('GET');
-    request.flush({ chatId: '12345' });
+    request.flush({
+      phoneNumber: '994551234567',
+      chatId: '12345',
+      lastSyncedAt: '2024-01-01T00:00:00.000Z',
+      botTokenConfigured: true
+    });
   });
 
-  it('should update the telegram chat id', () => {
-    service.updateSettings('6789').subscribe();
+  it('should update the telegram phone number', () => {
+    service.updateSettings('+994 (55) 678 90 00').subscribe();
 
     const request = httpMock.expectOne('/api/settings/telegram');
     expect(request.request.method).toBe('PUT');
-    expect(request.request.body).toEqual({ chatId: '6789' });
-    request.flush({ chatId: '6789' });
+    expect(request.request.body).toEqual({ phoneNumber: '+994 (55) 678 90 00' });
+    request.flush({
+      phoneNumber: '994556789000',
+      chatId: '6789',
+      lastSyncedAt: '2024-01-01T00:00:00.000Z',
+      botTokenConfigured: true
+    });
   });
 });

--- a/apps/web/src/app/data-access/services/telegram-settings.service.ts
+++ b/apps/web/src/app/data-access/services/telegram-settings.service.ts
@@ -14,7 +14,7 @@ export class TelegramSettingsService {
     return this.http.get<TelegramSettings>(this.endpoint);
   }
 
-  updateSettings(chatId: string) {
-    return this.http.put<TelegramSettings>(this.endpoint, { chatId });
+  updateSettings(phoneNumber: string) {
+    return this.http.put<TelegramSettings>(this.endpoint, { phoneNumber });
   }
 }

--- a/apps/web/src/app/pages/admin/telegram-settings.page.spec.ts
+++ b/apps/web/src/app/pages/admin/telegram-settings.page.spec.ts
@@ -25,7 +25,13 @@ describe('TelegramSettingsPageComponent', () => {
         {
           provide: TelegramSettingsService,
           useValue: {
-            getSettings: () => of({ chatId: '12345' }),
+            getSettings: () =>
+              of({
+                phoneNumber: '994551234567',
+                chatId: '12345',
+                lastSyncedAt: '2024-01-01T00:00:00.000Z',
+                botTokenConfigured: true
+              }),
             updateSettings: () => updateSubject.asObservable()
           }
         },
@@ -43,13 +49,13 @@ describe('TelegramSettingsPageComponent', () => {
     await fixture.whenStable();
   });
 
-  it('loads the current chat id into the form', () => {
-    const input = element.querySelector('input[formcontrolname="chatId"]') as HTMLInputElement;
-    expect(input.value).toBe('12345');
+  it('loads the current phone number into the form', () => {
+    const input = element.querySelector('input[formcontrolname="phoneNumber"]') as HTMLInputElement;
+    expect(input.value).toBe('994551234567');
   });
 
-  it('validates the chat id field and shows an error message when empty', async () => {
-    const input = element.querySelector('input[formcontrolname="chatId"]') as HTMLInputElement;
+  it('validates the phone number field and shows an error message when empty', async () => {
+    const input = element.querySelector('input[formcontrolname="phoneNumber"]') as HTMLInputElement;
     input.value = '';
     input.dispatchEvent(new Event('input'));
     input.dispatchEvent(new Event('blur'));
@@ -63,12 +69,17 @@ describe('TelegramSettingsPageComponent', () => {
     );
   });
 
-  it('submits the chat id and shows a success toast', async () => {
+  it('submits the phone number and shows a success toast', async () => {
     const form = element.querySelector('form') as HTMLFormElement;
     form.dispatchEvent(new Event('submit'));
     fixture.detectChanges();
 
-    updateSubject.next({});
+    updateSubject.next({
+      phoneNumber: '994551234567',
+      chatId: '12345',
+      lastSyncedAt: '2024-01-01T00:00:00.000Z',
+      botTokenConfigured: true
+    });
     updateSubject.complete();
     await fixture.whenStable();
 

--- a/apps/web/src/app/testing/en-translations.fixture.ts
+++ b/apps/web/src/app/testing/en-translations.fixture.ts
@@ -205,26 +205,30 @@ export const enTranslations = {
     telegram: {
       badge: 'Admin',
       title: 'Telegram notifications',
-      description: 'Set the Telegram chat ID that will receive order submissions.',
-      lastUpdated: 'Last updated {{timestamp}}',
+      description:
+        'Enter the phone number linked to the Telegram account that should receive order submissions. Make sure the account has started a chat with your bot and shared their contact details.',
+      lastUpdated: 'Last synced {{timestamp}}',
       form: {
-        chatId: {
-          label: 'Telegram chat ID',
-          hint: 'Use the numeric chat ID or group ID (include the leading - for groups).',
-          placeholder: 'Enter chat ID'
+        phoneNumber: {
+          label: 'Phone number',
+          hint: 'Use the full number. We will automatically match it to the chat once the bot sees the contact.',
+          placeholder: '+994 55 123 45 67'
         },
         actions: {
           save: 'Save settings'
         },
         errors: {
-          required: 'Chat ID is required.',
-          pattern: 'Use digits only and include a leading dash for groups.',
+          required: 'Phone number is required.',
+          pattern: 'Use digits, spaces, brackets or plus sign only.',
           generic: 'Update failed. Try again.'
-        }
+        },
+        missingBotToken:
+          'The Telegram bot token is missing. Update the configuration file or environment variable and reload this page.',
+        currentChat: 'Current chat ID: {{chat}}'
       },
       notifications: {
-        saved: 'Telegram chat ID updated.',
-        saveError: 'Unable to update Telegram chat ID. Try again.',
+        saved: 'Telegram recipient updated.',
+        saveError: 'Unable to update Telegram recipient. Try again.',
         loadError: 'Unable to load Telegram settings.'
       }
     }


### PR DESCRIPTION
## Summary
- add a BotFather automation module that can provision Telegram bot tokens from configuration and update bot metadata
- extend the bootstrap pipeline to consume the automation output, persist tokens, and surface run status in the config file
- add supporting utilities and dependencies for the automation workflow

## Testing
- npm test -- --watch=false (apps/web)


------
https://chatgpt.com/codex/tasks/task_e_68e510e23564832a9ac908fa439e87b6